### PR TITLE
Switch KCVS caching to LFU and make cache duration MASKABlE

### DIFF
--- a/janusgraph-core/pom.xml
+++ b/janusgraph-core/pom.xml
@@ -80,6 +80,11 @@
            <groupId>com.google.code.findbugs</groupId>
            <artifactId>jsr305</artifactId>
        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.3.1</version>
+        </dependency>
     </dependencies>
     <build>
         <directory>${basedir}/target</directory>

--- a/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
+++ b/janusgraph-core/src/main/java/org/janusgraph/graphdb/configuration/GraphDatabaseConfiguration.java
@@ -375,7 +375,7 @@ public class GraphDatabaseConfiguration {
             "Entries are evicted when they reach this age even if the cache has room to spare. " +
             "Set to 0 to disable expiration (cache entries live forever or until memory pressure " +
             "triggers eviction when set to 0).",
-            ConfigOption.Type.GLOBAL_OFFLINE, 10000L);
+            ConfigOption.Type.MASKABLE, 10000L);
 
     /**
      * Configures the maximum number of recently-used vertices cached by a transaction. The smaller the cache size, the


### PR DESCRIPTION
Some improvements to DB level caching in Janus Graph.
1. Make cache duration MASKABLE.  This will allow the client to specify its tolerance to staleness, especially in read-only scenarios. 
2. Switch KCVS cache to Caffeine's tinyLFU. 

In scale testing across graph-walk operations (totally 4 million retrievals), the LFU cache outperformed Guava's LRU by 10x.  LFU achieved 50% hit-rate with 100 MB cache, while LRU required 1 GB to reach the same hit-rate. 

Note: Caffeine is already a dependency of tinkerpop, so this does not add anything new.